### PR TITLE
Add pkg-config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,24 @@ SRCS=		src/epoll.c src/timerfd.c src/signalfd.c src/common.c
 INCS=		include/sys/epoll.h include/sys/timerfd.h include/sys/signalfd.h
 VERSION_MAP=	Version.map
 
+FILES=		src/epoll-shim.pc
+FILESDIR=	${LIBDATADIR}/pkgconfig
+
 LIBDIR=		/usr/local/lib
 INCSDIR=	/usr/local/include/libepoll-shim/sys
+LIBDATADIR=	/usr/local/libdata
 
 CFLAGS+=	-I${.CURDIR}/include -pthread -Wall -Wextra -Wno-missing-prototypes -Wno-padded -Wno-missing-variable-declarations -Wno-thread-safety-analysis
 LDFLAGS+=	-pthread -lrt
 
+src/epoll-shim.pc: src/epoll-shim.pc.in
+	sed -e 's,@CMAKE_INSTALL_PREFIX@,/usr/local,' \
+		-e 's,@PROJECT_VERSION@,,' \
+		$> >$@
+
 distrib-dirs:
 	mkdir -p "${DESTDIR}/${LIBDIR}"
 	mkdir -p "${DESTDIR}/${INCSDIR}"
+	mkdir -p "${DESTDIR}/${FILESDIR}"
 
 .include <bsd.lib.mk>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,8 +11,10 @@ set_target_properties(epoll-shim PROPERTIES
   LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/../Version.map")
 set_target_properties(epoll-shim PROPERTIES SOVERSION 0)
 
+configure_file("epoll-shim.pc.in" "epoll-shim.pc" @ONLY)
 
 install(TARGETS epoll-shim LIBRARY             DESTINATION lib)
 install(FILES "${INCLUDES_DIR}/sys/epoll.h"    DESTINATION include/libepoll-shim/sys)
 install(FILES "${INCLUDES_DIR}/sys/signalfd.h" DESTINATION include/libepoll-shim/sys)
 install(FILES "${INCLUDES_DIR}/sys/timerfd.h"  DESTINATION include/libepoll-shim/sys)
+install(FILES "epoll-shim.pc"                  DESTINATION lib/pkgconfig)

--- a/src/epoll-shim.pc.in
+++ b/src/epoll-shim.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: epoll-shim
+URL: https://github.com/FreeBSDDesktop/epoll-shim
+Description: Small epoll implementation using kqueue
+Version: @PROJECT_VERSION@
+Libs: -L${libdir} -lepoll-shim
+Libs.private: -pthread -lrt
+Cflags: -I${includedir}/libepoll-shim


### PR DESCRIPTION
Some consumers want dependencies managed via pkg-config (e.g., Meson unlike CMake doesn't try to reinvent unnecessarily). This would help propagating static linking dependencies i.e., consumer libraries can just define `Requires.private: epoll-shim`.

```diff
diff --git a/devel/libepoll-shim/Makefile b/devel/libepoll-shim/Makefile
index a6294b99b345..bc2097af3d55 100644
--- a/devel/libepoll-shim/Makefile
+++ b/devel/libepoll-shim/Makefile
@@ -1,35 +1,39 @@
 # Created by: Johannes Lundberg <johalun0@gmail.com>
 # $FreeBSD$
 
 PORTNAME=	libepoll-shim
 PORTVERSION=	0.0.20181229
 CATEGORIES=	devel
 
+PATCH_SITES=	https://github.com/${GH_ACCOUNT}/${GH_PROJECT}/commit/
+PATCHFILES=	f569b1825690.patch:-p1
+
 MAINTAINER=	x11@FreeBSD.org
 COMMENT=	epoll shim implemented using kevent
 
 LICENSE=	MIT
 
 USE_GITHUB=	yes
 GH_ACCOUNT=	FreeBSDDesktop
 GH_PROJECT=	epoll-shim
 GH_TAGNAME=	212c17b
 
 USE_LDCONFIG=	yes
 
 USES=		compiler uidfix
 MAKE_ARGS=	INCSDIR=${PREFIX}/include/libepoll-shim/sys \
+		LIBDATADIR=${PREFIX}/libdata \
 		LIBDIR=${PREFIX}/lib WITHOUT_PROFILE=yes
 
 .include <bsd.port.pre.mk>
 
 post-patch:
 .if "${CHOSEN_COMPILER_TYPE}" == "gcc"
 	@${REINPLACE_CMD} -e 's|Wno-missing-variable-declarations|Wno-missing-declarations|' \
 		-e 's|-Wno-thread-safety-analysis||' ${WRKSRC}/Makefile
 .endif
 
 pre-install:
 	@${MKDIR} ${STAGEDIR}/${PREFIX}/include/libepoll-shim/sys
 
 .include <bsd.port.post.mk>
diff --git a/devel/libepoll-shim/distinfo b/devel/libepoll-shim/distinfo
index 67ec24f86f8b..16999d75382b 100644
--- a/devel/libepoll-shim/distinfo
+++ b/devel/libepoll-shim/distinfo
@@ -1,3 +1,5 @@
 TIMESTAMP = 1546110650
 SHA256 (FreeBSDDesktop-epoll-shim-0.0.20181229-212c17b_GH0.tar.gz) = 819ec3de3ab233487d5be5fe506b23b81c05ee5daf5db1440ede76231615a86a
 SIZE (FreeBSDDesktop-epoll-shim-0.0.20181229-212c17b_GH0.tar.gz) = 15833
+SHA256 (f569b1825690.patch) = c802f89ddb37c4b7ada0e90cf2c3f8bd4e128e7104fe4e7337ad4be1935c0066
+SIZE (f569b1825690.patch) = 2596
diff --git a/devel/libepoll-shim/pkg-plist b/devel/libepoll-shim/pkg-plist
index 286712623c63..13394d677185 100644
--- a/devel/libepoll-shim/pkg-plist
+++ b/devel/libepoll-shim/pkg-plist
@@ -1,6 +1,7 @@
 include/libepoll-shim/sys/epoll.h
 include/libepoll-shim/sys/signalfd.h
 include/libepoll-shim/sys/timerfd.h
 lib/libepoll-shim.a
 lib/libepoll-shim.so
 lib/libepoll-shim.so.0
+libdata/pkgconfig/epoll-shim.pc
```
